### PR TITLE
Set @type for record entity

### DIFF
--- a/lxltools/datacompiler.py
+++ b/lxltools/datacompiler.py
@@ -133,6 +133,7 @@ class Compiler:
         created_ms = datasource_created_ms + faux_offset(node_id)
 
         record = OrderedDict()
+        record['@type'] = 'Record'
         record['@id'] = self.generate_record_id(created_ms, node_id)
         record[self.record_thing_link] = {'@id': node_id}
 


### PR DESCRIPTION
## Checklist
- [x] Tested locally by making the same change in definitions/src/lxltools/lxltools/datacompiler.py
- [ ] Possible to test in any other way? I'm not sure how lxltools is loaded into definitions...

## Description
Descriptions created by definitions lacks `"@type": "Record"` in `@graph [0]`, which creates problems for frontend (can't display "Adminmetadata") and backend (can't make `toChip(@graph[0])`).
This fix adds `"@type": "Record"` to record entities created in definitions. Tested it **locally** and verified that all datasets mentioned in [LXL-3098](https://jira.kb.se/browse/LXL-3098) gets updated.

## Issue
[LXL-3098](https://jira.kb.se/browse/LXL-3098)